### PR TITLE
Add TonConnect manifest and env var configuration

### DIFF
--- a/public/tonconnect-manifest.json
+++ b/public/tonconnect-manifest.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://example.com",
+  "name": "YourApp",
+  "iconUrl": "https://example.com/icon.png",
+  "termsOfUseUrl": "...",
+  "privacyPolicyUrl": "..."
+}

--- a/src/src/config.ts
+++ b/src/src/config.ts
@@ -1,7 +1,12 @@
 // Safe environment variable access
 const getEnvVar = (key: string, defaultValue: string = ''): string => {
   try {
-    return (typeof process !== 'undefined' && process.env?.[key]) || defaultValue
+    return (
+      // Vite exposes variables through import.meta.env
+      (typeof import.meta !== 'undefined' && (import.meta as any).env?.[key]) ||
+      (typeof process !== 'undefined' && (process as any).env?.[key]) ||
+      defaultValue
+    )
   } catch {
     return defaultValue
   }


### PR DESCRIPTION
## Summary
- add TON Connect manifest to the public folder so it is served with the app
- read config values from both `import.meta.env` and `process.env` so `VITE_TON_CONNECT_MANIFEST_URL` can set the manifest address

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af0da152e48323a0bdaa4a1ca80ae2