### PR TITLE
Fix wallet balance display and enforce stake limits

### DIFF
--- a/src/components/CreateGamePanel.tsx
+++ b/src/components/CreateGamePanel.tsx
@@ -1,20 +1,22 @@
 import { useState } from 'react'
+import { toast } from 'sonner@2.0.3'
 import { Card } from './ui/card'
 import { Button } from './ui/button'
 import { Input } from './ui/input'
 import { Label } from './ui/label'
 import { RadioGroup, RadioGroupItem } from './ui/radio-group'
 import { Separator } from './ui/separator'
-import { 
-  Clock, 
-  Users, 
-  Coins, 
-  Plus, 
+import {
+  Clock,
+  Users,
+  Coins,
+  Plus,
   Info,
   Calendar,
   Target
 } from 'lucide-react'
 import { Alert, AlertDescription } from './ui/alert'
+import { formatTon, nanotonToTon } from '../src/lib/ton-format'
 
 interface CreateGamePanelProps {
   onCreateRound: (roundData: {
@@ -25,14 +27,14 @@ interface CreateGamePanelProps {
   }) => void
   platformFeePercent: number
   disabled?: boolean
-  walletBalance: string
+  walletBalance: bigint
 }
 
 export function CreateGamePanel({ 
   onCreateRound, 
-  platformFeePercent, 
+  platformFeePercent,
   disabled = false,
-  walletBalance 
+  walletBalance
 }: CreateGamePanelProps) {
   const [mode, setMode] = useState<'TIME_LOCKED' | 'CAPACITY_LOCKED'>('TIME_LOCKED')
   const [stakeTON, setStakeTON] = useState('')
@@ -47,6 +49,12 @@ export function CreateGamePanel({
 
     const stake = parseFloat(stakeTON)
     if (isNaN(stake) || stake <= 0) {
+      return
+    }
+
+    const available = nanotonToTon(walletBalance)
+    if (stake > available) {
+      toast.error('Недостаточно баланса')
       return
     }
 
@@ -179,7 +187,7 @@ export function CreateGamePanel({
             />
             <div className="flex justify-between text-sm text-muted-foreground">
               <span>Минимум: 0.1 TON</span>
-              <span>Баланс: {walletBalance}</span>
+              <span>Баланс: {formatTon(walletBalance)}</span>
             </div>
           </div>
 

--- a/src/components/TabContent.tsx
+++ b/src/components/TabContent.tsx
@@ -8,7 +8,6 @@ import { Button } from './ui/button'
 import { Gamepad2, History, Plus, RefreshCw } from 'lucide-react'
 import { t } from '../src/i18n'
 import { CONFIG } from '../src/config'
-import { formatTon } from '../src/lib/ton-format'
 
 interface TabContentProps {
   activeTab: 'games' | 'history' | 'create' | 'profile'
@@ -155,7 +154,7 @@ export function TabContent({
           onCreateRound={onCreateRound}
           platformFeePercent={CONFIG.PLATFORM_FEE_BPS / 100}
           disabled={!isWalletConnected || !isValidNetwork}
-          walletBalance={formatTon(walletBalance)}
+          walletBalance={walletBalance}
         />
       </div>
     )


### PR DESCRIPTION
## Summary
- expose generic getWalletBalance and use it for balance lookups
- guard game creation/joining when wallet balance is missing or insufficient
- always load wallet balance once an address is available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0872fac8c83238f732dcba64fb40b